### PR TITLE
Template.contentBlock and @index

### DIFF
--- a/react-regex.js
+++ b/react-regex.js
@@ -174,5 +174,10 @@ ReactRegex = [
   {
     regex: /\stabindex=/g,
     replace: " tabIndex="
+  },
+  // Template.contentBlock
+  {
+    regex: /({{>\s*Template.contentBlock\s*}})/g,
+    replace: "{this.props.children}"
   }
 ];

--- a/react-regex.js
+++ b/react-regex.js
@@ -179,5 +179,10 @@ ReactRegex = [
   {
     regex: /({{>\s*Template.contentBlock\s*}})/g,
     replace: "{this.props.children}"
+  },
+  // @index -- match @index by itself {{@index}} or as a param to helper {{helper @index anotherParam}}
+  {
+    regex: /({{.*@index.*}})/g,
+    replace: "{index}"
   }
 ];


### PR DESCRIPTION
i used `\s*` instead of `\s+` because spaces arent required. ...also note: this won't actually be encountered until we build the lookup that handles templates used as a helper, i.e. the place where `contentBlock` comes from.
